### PR TITLE
To Dev - Add sad_path for invalid access_token for recommendation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Base Url
-`https://guten-server.herokuapp.com/`
+`https://micro-guten.herokuapp.com/`
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 `GET api/v1/recommendation`
 
 **Description:** A user turns a new page in their Gutenberg book. A GET request is sent to `/api/v1/recommendation`. The request includes the user's access_token, user_id, and the new page's full text in the request body. 
-The endpoint conducts a sentiment analysis on the text and returns a value of either 1(Positive), 0.5(Neutral), or 0(Negative) internally. The sentiment value and access_token is used to call Spotify's track recommendation endpoint. The track recommendation endpoint returns a classical track with either a positive, neural, or negative mood. The recommendation endpoint also returns the artist and name of the recommendation track. 
+The endpoint conducts a sentiment analysis on the text and returns a value of either 1(Positive), 0.5(Neutral), or 0(Negative) internally. The sentiment value and access_token is used to call Spotify's track recommendation endpoint. The track recommendation endpoint returns a classical track with either a positive, neural, or negative mood with the attributes artist, track_name, track_id, and track_uri.
+
+### ATTENTION: Use the track_uri to play the song in Spotify.
 
 Note: 
 - access_token expires hourly. In future iterations, sad path will be built in to automatically request and use an new access token. 
@@ -33,15 +35,21 @@ Accept: application/json
 status: 200
 
 {
-  "artist": "George Frideric Handel",
-  "track_id": "1kr73pbla9W6iI4HMkT9aP",
-  "track_name": "Messiah, HWV 56: Part II, Sc. 6, Hallelujah!"
+  "artist": "Modest Mussorgsky",
+  "track_id": "67F2FBLJL9Wn09qvPe6XVa",
+  "track_name": "Night on Bare Mountain",
+  "track_uri": "spotify:track:67F2FBLJL9Wn09qvPe6XVa"
 }
 
 ```
 
 **Unsuccessful Response**
 ```
+status: 401
+{
+  "error": "invalid token"
+}
+
 status: 400
 
 {

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ def hello():
 
 @app.route('/api/v1/monkeylearn')
 def monkeylearn():
+
     text = request.json['text']
     service = MonkeyLearnService(text)
     sentiment = service.text_sentiment()
@@ -24,6 +25,7 @@ def monkeylearn():
 
 @app.route('/api/v1/recommendation')
 def recommendation():
+
     text = request.json['text']
     access_token = request.json['access_token']
     user_id = request.json['user_id']
@@ -32,10 +34,9 @@ def recommendation():
     sentiment_value = monkeylearn_service.mood_value()
 
     spotify_service = SpotifyService()
-    # takes in access_token for authorization, user_id for potential sad path
     recommend_track = spotify_service.recommend(access_token, user_id, sentiment_value)
 
-    return jsonify(recommend_track)
+    return jsonify(recommend_track['message']), recommend_track['status_code']
 
 
 if __name__ == '__main__':

--- a/services/spotify_service.py
+++ b/services/spotify_service.py
@@ -7,27 +7,22 @@ class SpotifyService:
 
         if spotify_recommendation.status_code == 200:
             body = spotify_recommendation.json()
-            return {
+            return { 'message': {
                     'artist': body['tracks'][0]['artists'][0]["name"],
                     'track_id': body['tracks'][0]['id'],
                     'track_name': body['tracks'][0]['name'],
                     'track_uri': body['tracks'][0]['uri']
-                    }
+                    }, 'status_code': 200 }
         elif spotify_recommendation.status_code == 401:
-            # 401 status code if access_token expired
-            # add logic to make GET request to rails app for user's updated access_token
-            # could use user_id or access_token to denote specific user
-            # GET request returns updated access_token
-            # use updated access_token to make new get_spotify_recommendation request
-            # if second recommendation API sucessful then...
-                # return track_id
-            # if second_recommendation API fail then...
-                # return error message
+            request = requests.get(f'https://guten-server.herokuapp.com/api/v1/access_token/{user_id}')
 
-            #placeholder for invalid access_token sad path
-            return "invalid token"
+            if request.status_code == 200:
+                access_token = request.json()['access_token']
+                return self.recommend(access_token, user_id, sentiment_value)
+            else:
+                return { 'message': f"User:{user_id} does not exist", 'status_code': 404}
         else:
-            return "invalid request"
+            return { 'message': "Bad request", 'status_code': 400 }
 
     def song_params(self, sentiment_value):
         params = {
@@ -39,7 +34,7 @@ class SpotifyService:
             params['mode'] = 1
         elif sentiment_value == 0:
             params['mode'] = 0
-        
+
         return params
 
 


### PR DESCRIPTION
## Issue Number: #5 

### Description of Behavior
Sad path if access_token expired. If call to Spotify recommendation endpoint returns 401, then GET request made to our Rails app endpoint `api/v1/access_token/:user_id`. If successful, Spotify recommendation request is called again with update access_token. If invalid user_id, Flask recommendation endpoint returns status 404 with message "User: user_id does not exist". 

In later user story, need to add sad path to validate body params: text, user_id, and access_token. 

### Pull request checklist
Please check if your PR fulfills the following requirements:
- [ ] Tests are written
- [ ] Test coverage acceptable
- [x] Sad paths accounted for
- [x] Tested in Postman 

### Merge to
- [x] Development branch
- [ ] Master

### Additional Comments

