### PR TITLE
Amend rec endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [GutenReader](https://github.com/Guten-Reader/guten_reader_FE) is an app built in React Native for reading books hosted by [Project Gutenberg](https://www.gutenberg.org/). This microservice allows the app to play music that matches the current mood of the page the user is reading. GutenReader also uses a [Rails API](https://github.com/Guten-Reader/guten_reader_api) to handle database interaction.
 
 ## Installation
-NOTE: You will need to create an account at [monkeylearn.com](https://monkeylearn.com/) and include the API key and model id as environment variables MONKEYLEARN_KEY, MONKEYLEARN_MODEL_ID.
+NOTE: If running locally, you will need to create an account with [IMB Cloud](https://www.ibm.com/cloud/watson-natural-language-understanding). Once you create the account, from your user dashboard board click 'Create Resource' and then select 'Natural Language Understanding'. Click 'Create' and obtain the resources API Key and URL. In the Flask .env file, set the API Key equal to `WATSON_API` and the URL to `WATSON_URL`. 
+
 
 1. Clone the repository
 ```
@@ -47,6 +48,8 @@ $ nose2
 
 **Description:** A user turns a new page in their Gutenberg book. A GET request is sent to `/api/v1/recommendation`. The request includes the user's `access_token`, the `current_mood`, and the new page's full `text` in the request body. 
 The endpoint conducts a sentiment analysis on the text and returns a value of either 1(Positive), 0.5(Neutral), or 0(Negative) internally. The sentiment value and access_token is used to call Spotify's track recommendation endpoint. The track recommendation endpoint returns an array of 10 classical tracks (as track_uri) with either a positive, neutral, or negative mood.
+
+The body of the request requires an access_token. You can obtain an access_token by visiting the [access_token endpoint on our Rails app](http://guten-server.herokuapp.com/api/v1/access_token/1). Access_token expires hourly. 
 
 #### Note: Use the track_uri to play the song in Spotify.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [GutenReader](https://github.com/Guten-Reader/guten_reader_FE) is an app built in React Native for reading books hosted by [Project Gutenberg](https://www.gutenberg.org/). This microservice allows the app to play music that matches the current mood of the page the user is reading. GutenReader also uses a [Rails API](https://github.com/Guten-Reader/guten_reader_api) to handle database interaction.
 
 ## Installation
-NOTE: If running locally, you will need to create an account with [IMB Cloud](https://www.ibm.com/cloud/watson-natural-language-understanding). Once you create the account, from your user dashboard board click 'Create Resource' and then select 'Natural Language Understanding'. Click 'Create' and obtain the resources API Key and URL. In the Flask .env file, set the API Key equal to `WATSON_API` and the URL to `WATSON_URL`. 
+NOTE: If running locally, you will need to create an account with [IMB Cloud](https://www.ibm.com/cloud/watson-natural-language-understanding). Once you create the account, from your user dashboard click 'Create Resource' and then select 'Natural Language Understanding'. Click 'Create' and obtain the resources API Key and URL. In the Flask .env file, set the API Key equal to `WATSON_API` and the URL to `WATSON_URL`. 
 
 
 1. Clone the repository

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [GutenReader](https://github.com/Guten-Reader/guten_reader_FE) is an app built in React Native for reading books hosted by [Project Gutenberg](https://www.gutenberg.org/). This microservice allows the app to play music that matches the current mood of the page the user is reading. GutenReader also uses a [Rails API](https://github.com/Guten-Reader/guten_reader_api) to handle database interaction.
 
 ## Installation
-NOTE: If running locally, you will need to create an account with [IMB Cloud](https://www.ibm.com/cloud/watson-natural-language-understanding). Once you create the account, from your user dashboard click 'Create Resource' and then select 'Natural Language Understanding'. Click 'Create' and obtain the resources API Key and URL. In the Flask .env file, set the API Key equal to `WATSON_API` and the URL to `WATSON_URL`. 
+NOTE: If running locally, you will need to create an account with [IMB Cloud](https://www.ibm.com/cloud/watson-natural-language-understanding). Once you create the account, from your user dashboard click 'Create Resource' and then select 'Natural Language Understanding'. Click 'Create' and obtain the resource's API Key and URL. In the Flask .env file, set the API Key equal to `WATSON_API` and the URL to `WATSON_URL`. 
 
 
 1. Clone the repository

--- a/app.py
+++ b/app.py
@@ -44,7 +44,7 @@ def recommendation():
     new_mood = watson_service.get_sentiment_value()
 
     if body['current_mood'] != new_mood:
-        spotify_service = SpotifyService(body['access_token'], new_mood)
+        spotify_service = SpotifyService(body['access_token'], new_mood, body['genre'])
         result = spotify_service.recommend()
         return jsonify(result), result['status_code']
     else:

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def monkeylearn():
 @app.route('/api/v1/recommendation', methods=["POST"])
 def recommendation():
     body =  {} if request.get_data() == b'' else request.get_json()
-    required_params = {'text', 'current_mood', 'access_token'}
+    required_params = {'text', 'current_mood', 'access_token', 'genre'}
     missing_params = list(required_params - set(body.keys()))
 
     if missing_params:

--- a/services/spotify_service.py
+++ b/services/spotify_service.py
@@ -1,7 +1,7 @@
 import requests
 
 class SpotifyService:
-    def __init__(self, access_token, sentiment, genre='classical'):
+    def __init__(self, access_token, sentiment, genre):
         self.access_token = access_token
         self.sentiment = sentiment
         self.genre = 'idm' if genre == 'electronic' else genre

--- a/services/spotify_service.py
+++ b/services/spotify_service.py
@@ -1,9 +1,10 @@
 import requests
 
 class SpotifyService:
-    def __init__(self, access_token, sentiment):
+    def __init__(self, access_token, sentiment, genre='classical'):
         self.access_token = access_token
         self.sentiment = sentiment
+        self.genre = 'idm' if genre == 'electronic' else genre
 
 
     def recommend(self):
@@ -17,8 +18,9 @@ class SpotifyService:
 
     def song_params(self):
         params = {
-            'seed_genres': 'classical',
-            'limit': 10 }
+            'seed_genres': self.genre,
+            'limit': 10
+        }
         if self.sentiment == 1:
             params['mode']    = 1
             params['valence'] = 1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -119,6 +119,7 @@ class TestHello(unittest.TestCase):
     @patch('services.spotify_service.requests.get')
     @patch.object(WatsonService, 'get_watson_text_analyze')
     def test_POST_recommendation_called_with_specific_params(self, mock_sentiment, mock_get):
+        # Set up mock functions
         file_path = 'tests/fixtures/watson_positive.json'
         with open(file_path) as json_file:
             ml_data = json.load(json_file)
@@ -132,6 +133,7 @@ class TestHello(unittest.TestCase):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = tracks_data
 
+        # Check that Spotify API is called with correct parameters when genre setting is 'classical'
         data = {
             'text': 'Super positive great happy fun awesome great wonderful times',
             'current_mood': 0,
@@ -154,6 +156,7 @@ class TestHello(unittest.TestCase):
             }
         )
 
+        # Check that Spotify API is called with correct parameters when genre setting is 'piano'
         data2 = {
             'text': 'Super positive great happy fun awesome great wonderful times',
             'current_mood': 0,
@@ -176,6 +179,7 @@ class TestHello(unittest.TestCase):
             }
         )
 
+        # Check that Spotify API is called with correct parameters when genre setting is 'electronic'
         data3 = {
             'text': 'Super positive great happy fun awesome great wonderful times',
             'current_mood': 0,
@@ -197,6 +201,7 @@ class TestHello(unittest.TestCase):
                 'limit': 10
             }
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -76,7 +76,8 @@ class TestHello(unittest.TestCase):
         data = {
             'text': 'Super positive great happy fun awesome great wonderful times',
             'current_mood': 0,
-            'access_token': 'totally-real-access-token'
+            'access_token': 'totally-real-access-token',
+            'genre': 'classical'
         }
 
         response = self.app.post('/api/v1/recommendation',
@@ -104,7 +105,8 @@ class TestHello(unittest.TestCase):
         new_data = {
             'text': 'Super positive great happy fun times',
             'current_mood': 1,
-            'access_token': 'totally-real-access-token'
+            'access_token': 'totally-real-access-token',
+            'genre': 'classical'
         }
 
         response = self.app.post('/api/v1/recommendation',
@@ -112,6 +114,7 @@ class TestHello(unittest.TestCase):
                                 content_type='application/json')
 
         self.assertEqual(204, response.status_code)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -116,5 +116,87 @@ class TestHello(unittest.TestCase):
         self.assertEqual(204, response.status_code)
 
 
+    @patch('services.spotify_service.requests.get')
+    @patch.object(WatsonService, 'get_watson_text_analyze')
+    def test_POST_recommendation_called_with_specific_params(self, mock_sentiment, mock_get):
+        file_path = 'tests/fixtures/watson_positive.json'
+        with open(file_path) as json_file:
+            ml_data = json.load(json_file)
+
+        mock_sentiment.return_value = ml_data
+
+        file_path = 'tests/fixtures/spotify_tracks.json'
+        with open(file_path) as json_file:
+            tracks_data = json.load(json_file)
+
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = tracks_data
+
+        data = {
+            'text': 'Super positive great happy fun awesome great wonderful times',
+            'current_mood': 0,
+            'access_token': 'totally-real-access-token',
+            'genre': 'classical'
+        }
+
+        response = self.app.post('/api/v1/recommendation',
+                                 data=json.dumps(data),
+                                 content_type='application/json')
+
+        mock_get.assert_called_with(
+            'https://api.spotify.com/v1/recommendations',
+            headers={'Authorization': 'Bearer totally-real-access-token'},
+            params={
+                'valence': 1,
+                'mode': 1,
+                'seed_genres': 'classical',
+                'limit': 10
+            }
+        )
+
+        data2 = {
+            'text': 'Super positive great happy fun awesome great wonderful times',
+            'current_mood': 0,
+            'access_token': 'totally-real-access-token',
+            'genre': 'piano'
+        }
+
+        response = self.app.post('/api/v1/recommendation',
+                                 data=json.dumps(data2),
+                                 content_type='application/json')
+
+        mock_get.assert_called_with(
+            'https://api.spotify.com/v1/recommendations',
+            headers={'Authorization': 'Bearer totally-real-access-token'},
+            params={
+                'valence': 1,
+                'mode': 1,
+                'seed_genres': 'piano',
+                'limit': 10
+            }
+        )
+
+        data3 = {
+            'text': 'Super positive great happy fun awesome great wonderful times',
+            'current_mood': 0,
+            'access_token': 'totally-real-access-token',
+            'genre': 'electronic'
+        }
+
+        response = self.app.post('/api/v1/recommendation',
+                                 data=json.dumps(data3),
+                                 content_type='application/json')
+
+        mock_get.assert_called_with(
+            'https://api.spotify.com/v1/recommendations',
+            headers={'Authorization': 'Bearer totally-real-access-token'},
+            params={
+                'valence': 1,
+                'mode': 1,
+                'seed_genres': 'idm',
+                'limit': 10
+            }
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_recommendation_bad_request.py
+++ b/tests/test_recommendation_bad_request.py
@@ -9,8 +9,9 @@ class TestRecommendationSadPath(unittest.TestCase):
 
     def test_recommendation_missing_single_param(self):
         data = {
-            "current_mood": "Negative",
-            "access_token": "this-is-totally-an-access-token"
+            'current_mood': 'Negative',
+            'access_token': 'this-is-totally-an-access-token',
+            'genre': 'classical'
         }
         response = self.app.post('/api/v1/recommendation',
                                 data=json.dumps(data),
@@ -30,7 +31,7 @@ class TestRecommendationSadPath(unittest.TestCase):
 
         data = response.get_json()
         data_missing_params = set(data['error']['missing_params'])
-        expected_missing_params = set(["text", "current_mood", "access_token"])
+        expected_missing_params = set(['text', 'current_mood', 'access_token', 'genre'])
         self.assertSetEqual(expected_missing_params, data_missing_params)
 
     def test_recommendation_with_empty_body(self):
@@ -41,7 +42,7 @@ class TestRecommendationSadPath(unittest.TestCase):
 
         data = response.get_json()
         data_missing_params = set(data['error']['missing_params'])
-        expected_missing_params = set(["text", "current_mood", "access_token"])
+        expected_missing_params = set(['text', 'current_mood', 'access_token', 'genre'])
         self.assertSetEqual(expected_missing_params, data_missing_params)
 
 

--- a/tests/test_spotify_service.py
+++ b/tests/test_spotify_service.py
@@ -12,7 +12,7 @@ class TestSpotifyService(unittest.TestCase):
 
 
     def test_song_params_for_positive_mood(self):
-        service = SpotifyService('token', 1)
+        service = SpotifyService('token', 1, 'classical')
         result = service.song_params()
         expected = {
             'valence': 1,
@@ -24,7 +24,7 @@ class TestSpotifyService(unittest.TestCase):
 
 
     def test_song_params_for_neutral_mood(self):
-        service = SpotifyService('token', 0.5)
+        service = SpotifyService('token', 0.5, 'classical')
         result = service.song_params()
         expected = {
             'valence': 0.5,
@@ -35,7 +35,7 @@ class TestSpotifyService(unittest.TestCase):
 
 
     def test_song_params_for_negative_mood(self):
-        service = SpotifyService('token', 0)
+        service = SpotifyService('token', 0, 'classical')
         result = service.song_params()
         expected = {
             'valence': 0,
@@ -77,7 +77,7 @@ class TestSpotifyService(unittest.TestCase):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = tracks_data
 
-        service = SpotifyService('token', 'Positive')
+        service = SpotifyService('token', 'Positive', 'classical')
         result = service.recommend()
 
         expected = {
@@ -108,7 +108,7 @@ class TestSpotifyService(unittest.TestCase):
         mock_get.return_value.status_code = 401
         mock_get.return_value.json.return_value = message
 
-        service = SpotifyService('token', 'Positive')
+        service = SpotifyService('token', 'Positive', 'classical')
         result = service.recommend()
 
         expected = { 'message': 'The access token expired', 'status_code': 401 }

--- a/tests/test_spotify_service.py
+++ b/tests/test_spotify_service.py
@@ -45,6 +45,28 @@ class TestSpotifyService(unittest.TestCase):
         }
         self.assertDictEqual(expected, result)
 
+    
+    def test_song_params_for_piano_genre(self):
+        service = SpotifyService('token', 0.5, 'piano')
+        result = service.song_params()
+        expected = {
+            'valence': 0.5,
+            'seed_genres': 'piano',
+            'limit': 10
+        }
+        self.assertDictEqual(expected, result)
+
+    
+    def test_song_params_for_electronic_genre(self):
+        service = SpotifyService('token', 0.5, 'electronic')
+        result = service.song_params()
+        expected = {
+            'valence': 0.5,
+            'seed_genres': 'idm',
+            'limit': 10
+        }
+        self.assertDictEqual(expected, result)
+
 
     @patch('services.spotify_service.requests.get')
     def test_recommend_happy_path(self, mock_get):


### PR DESCRIPTION
<!-- Title [Merging To] - [User story description] -->

## Issue Number: #34

### Description of Behavior
<!-- Overview of behavior of new functionality. -->
- The old endpoint /api/v1/recommendation took a JSON body with attributes `text`, `access_token`, and `user_id`
- The amended endpoint requires a 4th parameter, `genre` in the JSON body to search Spotify recommendations based on user's music preference.
- Preference allowed values should be: 'classical', 'piano', or 'electronic' (converted to 'idm' for Spotify endpoint)
- Includes tests for SpotifyService `song_params()`, updated bad request test for missing genre, and updated `app.py` test for checking that Spotify API is called with the correct parameters

### Pull request checklist
Please check if your PR fulfills the following requirements:
- [x] Tests are written
- [x] Test coverage acceptable
- [x] Sad paths accounted for
- [x] Tested in Postman 

### Merge to
- [x] Development branch
- [ ] Master

### Additional Comments
<!-- Any other information that is important to this PR such as new models or updates to the database -->
Tested in Postman to verify that tracks returned match the requested genre: PASS